### PR TITLE
Update the public key

### DIFF
--- a/Dockerfile.ur3_erc
+++ b/Dockerfile.ur3_erc
@@ -1,5 +1,7 @@
 FROM osrf/ros:melodic-desktop-full
 
+RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+
 RUN apt-get update && apt-get upgrade -y && \
 	apt-get install -y lsb-core g++ openssh-server gedit vim
 


### PR DESCRIPTION
Added line to update the public key used for ROS apt repositories

Before, I was getting followig error while building dockerfile.
![Error_Key_expired](https://user-images.githubusercontent.com/65353181/126121928-360b7879-41a9-452b-aad0-41a7fac40e61.jpeg)

To resolve, I followed the advice in the forum.
https://answers.ros.org/question/379190/apt-update-signatures-were-invalid-f42ed6fbab17c654/